### PR TITLE
Update Cellcom plans

### DIFF
--- a/docs/data/plans.json
+++ b/docs/data/plans.json
@@ -9,19 +9,19 @@
   },
   {
     "company_name": "סלקום אנרג'י",
-    "plan_description": "חוסכים משפחה",
+    "plan_description": "חוסכים למשפחה",
     "plan_link": "https://cellcom.co.il/production/Private/1/energy3/",
     "days_of_week": [0, 1, 2, 3, 4, 5, 6],
-    "applicable_hours": [14, 15, 16, 17, 18, 19, 20],
-    "discount": [20]
+    "applicable_hours": [14, 15, 16, 17, 18, 19],
+    "discount": [18]
   },
   {
     "company_name": "סלקום אנרג'י",
     "plan_description": "חוסכים בלילה",
     "plan_link": "https://cellcom.co.il/production/Private/1/energy3/",
     "days_of_week": [0, 1, 2, 3, 4],
-    "applicable_hours": [22, 23, 0, 1, 2, 3, 4, 5, 6],
-    "discount": [18]
+    "applicable_hours": [23, 0, 1, 2, 3, 4, 5, 6],
+    "discount": [20]
   },
   {
     "company_name": "פרטנר חשמל",
@@ -49,7 +49,7 @@
   },
   {
     "company_name": "סלקום אנרג'י",
-    "plan_description": "עובדים מהבית",
+    "plan_description": "חוסכים ביום",
     "plan_link": "https://cellcom.co.il/production/Private/1/energy3/",
     "days_of_week": [0, 1, 2, 3, 4],
     "applicable_hours": [7, 8, 9, 10, 11, 12, 13, 14, 15, 16],


### PR DESCRIPTION
Update Cellcom's plans per https://cellcom.co.il/production/Private/1/energy3/
Also closes #31.

Changes made:
- Updated the name of "עובדים מהבית" to "חוסכים ביום".
- Updated the name of "חוסכים משפחה" to "חוסכים **ל**משפחה".
- 
Company | Plan | Discount | Applicable Hours
:--: | :--: | :--: | :--:
סלקום אנרג'י | חוסכים למשפחה | 20 -> **18** | 14:00-21:00 -> 14:00-**20:00**
סלקום אנרג'י | חוסכים בלילה | 18 -> **20** | 22:00-07:00 -> **23:00**-07:00

Thanks.

---

### Current plans (as of 2024-12-29)
![image](https://github.com/user-attachments/assets/2789745c-2ac4-4278-baf3-7e09ddc563d8)
