### PR TITLE
Added field for inactive plans

### DIFF
--- a/docs/data/plans.json
+++ b/docs/data/plans.json
@@ -5,23 +5,53 @@
     "plan_link": "https://sale.electra-power.co.il/",
     "days_of_week": [0, 1, 2, 3, 4, 5, 6],
     "applicable_hours": [23, 0, 1, 2, 3, 4, 5, 6],
-    "discount": [20]
+    "discount": [20],
+    "plan_active": true
   },
   {
     "company_name": "סלקום אנרג'י",
-    "plan_description": "חוסכים משפחה",
+    "plan_description": "חוסכים למשפחה - תוכנית ישנה",
     "plan_link": "https://cellcom.co.il/production/Private/1/energy3/",
     "days_of_week": [0, 1, 2, 3, 4, 5, 6],
     "applicable_hours": [14, 15, 16, 17, 18, 19, 20],
-    "discount": [20]
+    "discount": [20],
+    "plan_active": false
+  },
+  {
+    "company_name": "סלקום אנרג'י",
+    "plan_description": "חוסכים למשפחה",
+    "plan_link": "https://cellcom.co.il/production/Private/1/energy3/",
+    "days_of_week": [0, 1, 2, 3, 4, 5, 6],
+    "applicable_hours": [14, 15, 16, 17, 18, 19, 20],
+    "discount": [18],
+    "plan_active": true
+  },
+  {
+    "company_name": "סלקום אנרג'י",
+    "plan_description": "חוסכים בלילה - תוכנית ישנה",
+    "plan_link": "https://cellcom.co.il/production/Private/1/energy3/",
+    "days_of_week": [0, 1, 2, 3, 4],
+    "applicable_hours": [22, 23, 0, 1, 2, 3, 4, 5, 6],
+    "discount": [18],
+    "plan_active": false
   },
   {
     "company_name": "סלקום אנרג'י",
     "plan_description": "חוסכים בלילה",
     "plan_link": "https://cellcom.co.il/production/Private/1/energy3/",
+    "days_of_week": [0, 1, 2, 3, 4, 5, 6],
+    "applicable_hours": [23, 0, 1, 2, 3, 4, 5, 6],
+    "discount": [20],
+    "plan_active": true
+  },
+  {
+    "company_name": "סלקום אנרג'י",
+    "plan_description": "חוסכים בלילה - תוכנית ישנה",
+    "plan_link": "https://cellcom.co.il/production/Private/1/energy3/",
     "days_of_week": [0, 1, 2, 3, 4],
     "applicable_hours": [22, 23, 0, 1, 2, 3, 4, 5, 6],
-    "discount": [18]
+    "discount": [20],
+    "plan_active": false
   },
   {
     "company_name": "פרטנר חשמל",
@@ -29,7 +59,8 @@
     "plan_link": "https://www.partner.co.il/n/partnerpower/lobby",
     "days_of_week": [0, 1, 2, 3, 4],
     "applicable_hours": [0, 1, 2, 3, 4, 5],
-    "discount": [20]
+    "discount": [20],
+    "plan_active": true
   },
   {
     "company_name": "בזק חשמל",
@@ -37,7 +68,8 @@
     "plan_link": "https://www.bezeq.co.il/benergy/",
     "days_of_week": [0, 1, 2, 3, 4],
     "applicable_hours": [23, 0, 1, 2, 3, 4, 5, 6],
-    "discount": [20]
+    "discount": [20],
+    "plan_active": true
   },
    {
     "company_name": "הוט אנרג'י",
@@ -45,15 +77,17 @@
     "plan_link": "https://www.hot.net.il/heb/hotenergy/",
     "days_of_week": [0, 1, 2, 3, 4],
     "applicable_hours": [23, 0, 1, 2, 3, 4, 5, 6],
-    "discount": [20]
+    "discount": [20],
+    "plan_active": true
   },
   {
     "company_name": "סלקום אנרג'י",
-    "plan_description": "עובדים מהבית",
+    "plan_description": "עובדים מהבית/חוסכים ביום",
     "plan_link": "https://cellcom.co.il/production/Private/1/energy3/",
     "days_of_week": [0, 1, 2, 3, 4],
     "applicable_hours": [7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-    "discount": [15]
+    "discount": [15],
+    "plan_active": true
   },
   {
     "company_name": "פרטנר חשמל",
@@ -61,7 +95,8 @@
     "plan_link": "https://www.partner.co.il/n/partnerpower/lobby",
     "days_of_week": [0, 1, 2, 3, 4],
     "applicable_hours": [8, 9, 10, 11, 12, 13, 14, 15, 16],
-    "discount": [15]
+    "discount": [15],
+    "plan_active": true
   },
     {
     "company_name": "בזק חשמל",
@@ -69,7 +104,8 @@
     "plan_link": "https://www.bezeq.co.il/benergy/",
     "days_of_week": [0, 1, 2, 3, 4],
     "applicable_hours": [7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-    "discount": [15]
+    "discount": [15],
+    "plan_active": true
   },
      {
     "company_name": "הוט אנרג'י",
@@ -77,7 +113,8 @@
     "plan_link": "https://www.hot.net.il/heb/hotenergy/",
     "days_of_week": [0, 1, 2, 3, 4],
     "applicable_hours": [7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-    "discount": [15]
+    "discount": [15],
+    "plan_active": true
   },
   {
     "company_name": "פזגז חשמל",
@@ -85,7 +122,8 @@
     "plan_link": "https://hashmal.pazgas.co.il/hashmal/pickapackage",
     "days_of_week": [5, 6],
     "applicable_hours": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
-    "discount": [10]
+    "discount": [10],
+    "plan_active": true
   },
   {
     "company_name": "אלקטרה פאוור",
@@ -93,7 +131,8 @@
     "plan_link": "https://sale.electra-power.co.il/",
     "days_of_week": [0, 1, 2, 3, 4, 5, 6],
     "applicable_hours": [23, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-    "discount": [8, 9, 10]
+    "discount": [8, 9, 10],
+    "plan_active": true
   },
   {
     "company_name": "פזגז חשמל",
@@ -101,7 +140,8 @@
     "plan_link": "https://hashmal.pazgas.co.il/hashmal/pickapackage",
     "days_of_week": [0, 1, 2, 3, 4, 5, 6],
     "applicable_hours": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
-    "discount": [7]
+    "discount": [7],
+    "plan_active": true
   },
   {
     "company_name": "בזק חשמל",
@@ -109,7 +149,8 @@
     "plan_link": "https://www.bezeq.co.il/benergy/",
     "days_of_week": [0, 1, 2, 3, 4, 5, 6],
     "applicable_hours": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
-    "discount": [7]
+    "discount": [7],
+    "plan_active": true
   },
   {
     "company_name": "אמישראגז חשמל",
@@ -117,7 +158,8 @@
     "plan_link": "https://www.amisragas.co.il/electricity/",
     "days_of_week": [0, 1, 2, 3, 4, 5, 6],
     "applicable_hours": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
-    "discount": [6.5]
+    "discount": [6.5],
+    "plan_active": true
   },
   {
     "company_name": "אלקטרה פאוור",
@@ -125,7 +167,8 @@
     "plan_link": "https://sale.electra-power.co.il/",
     "days_of_week": [0, 1, 2, 3, 4, 5, 6],
     "applicable_hours": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
-    "discount": [5, 6, 7]
+    "discount": [5, 6, 7],
+    "plan_active": true
   },
   {
     "company_name": "סלקום אנרג'י",
@@ -133,7 +176,8 @@
     "plan_link": "https://cellcom.co.il/production/Private/1/energy3/",
     "days_of_week": [0, 1, 2, 3, 4, 5, 6],
     "applicable_hours": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
-    "discount": [5, 6, 7]
+    "discount": [5, 6, 7],
+    "plan_active": true
   },
   {
     "company_name": "פרטנר חשמל",
@@ -141,7 +185,8 @@
     "plan_link": "https://www.partner.co.il/n/partnerpower/lobby",
     "days_of_week": [0, 1, 2, 3, 4, 5, 6],
     "applicable_hours": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
-    "discount": [5, 6, 7]
+    "discount": [5, 6, 7],
+    "plan_active": true
   },
   {
     "company_name": "הוט אנרג'י",
@@ -149,7 +194,8 @@
     "plan_link": "https://www.hot.net.il/heb/hotenergy/",
     "days_of_week": [0, 1, 2, 3, 4, 5, 6],
     "applicable_hours": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
-    "discount": [5, 6, 7]
+    "discount": [5, 6, 7],
+    "plan_active": true
   },
   {
     "company_name": "הוט אנרג'י",
@@ -157,7 +203,8 @@
     "plan_link": "https://www.hot.net.il/heb/hotenergy/",
     "days_of_week": [0, 1, 2, 3, 4, 5, 6],
     "applicable_hours": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
-    "discount": [7]
+    "discount": [7],
+    "plan_active": true
   },
   {
     "company_name": "הוט אנרג'י",
@@ -165,7 +212,8 @@
     "plan_link": "https://www.hot.net.il/heb/hotenergy/",
     "days_of_week": [0, 1, 2, 3, 4, 5, 6],
     "applicable_hours": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
-    "discount": [10]
+    "discount": [10],
+    "plan_active": true
   },
   {
     "company_name": "הוט אנרג'י",

--- a/docs/js/script.js
+++ b/docs/js/script.js
@@ -290,6 +290,7 @@ function displayPlanResults(totalKwhFreePerPlan) {
                      <table>
                      <tr>
                         <th>דירוג</th>
+                        <th>תוכנית פעילה</th>
                         <th>שם חברה</th>
                         <th>שם תוכנית</th>
                         <th>בימים</th>
@@ -303,6 +304,7 @@ function displayPlanResults(totalKwhFreePerPlan) {
 
     tableHTML += `<tr${rowClass}>
                         <td>${index + 1}</td>
+                        <td>${plan.plan_active}</td>
                         <td>${plan.company_name}</td>
                         <td><a href="${plan.plan_link}" target="_blank" class="text-blue-500 hover:underline">${plan.plan_description}</a></td>
                         <td>${formatDaysOfWeek(plan.days_of_week)}</td>


### PR DESCRIPTION
 I added plan_active field to each plan, as well as ui.
The reason for this feature is that customers on an old plan can see if their plan is still the best, or they should change to a new plan.
Just showing existing plans is not enough, users want the ability to compare with old plans.

This will make updating the plans a bit easier - just add at the bottom, with `"plan_active": true` and remember to deactivate old plans.